### PR TITLE
Updates Plugin to work with Jekyll 4.x/Liquid 4.x and Updates To New Instagram API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 Jekyll Instagram aka Jekyllgram is a Jekyll plugin for displaying a feed of your recent Instagram photos.
 
-
-
 ### Installation and Setup
 
-To install this plugin into your project you will need to copy _plugins/jekyllgram.rb into the _plugins directory 
+To install this plugin into your project you will need to copy _plugins/jekyllgram.rb into the _plugins directory
 in your Jekyll project.
 
-For the plugin to work you will need to register an application with the Instagram API and then make your user id 
-and client id available as environment varibles below:
+For the plugin to work you will need to register an application with the Instagram API and then make your access token available as an environment varible like below:
 
 ```ruby
-ENV['JEKYLLGRAM_USER'] = {{ INSTAGRAM_USER_ID }}
-ENV['JEKYLLGRAM_KEY'] = {{ INSTAGRAM_CLIENT_ID }}
+ENV['JEKYLLGRAM_TOKEN'] = {{ INSTAGRAM_ACCESS_TOKEN }}
 ```
 
-
+@access_token = ENV['JEKYLLGRAM_TOKEN']
 
 ### Displaying the results in your templates
 

--- a/_plugins/jekyllgram.rb
+++ b/_plugins/jekyllgram.rb
@@ -11,11 +11,10 @@
 #
 # Setup:
 #
-# To use this plugin you will need to make your Instagram API credentials
-# available as environment variables below:
+# To use this plugin you will need to make your Instagram API access token
+# available as an environment variable like below:
 #
-# ENV['JEKYLLGRAM_USER'] = {{ INSTAGRAM_USER_ID }}
-# ENV['JEKYLLGRAM_KEY'] = {{ INSTAGRAM_CLIENT_ID }}
+# ENV['JEKYLLGRAM_TOKEN'] = {{ INSTAGRAM_ACCESS_TOKEN }}
 #
 # Usage in your templates:
 # You can replace the 6 below with the number of photos you wish to display

--- a/_plugins/jekyllgram.rb
+++ b/_plugins/jekyllgram.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Jekyllgram
 #
@@ -33,13 +35,11 @@ require 'json'
 module Jekyll
   # _plugins/jekyllgram.rb
   class Jekyllgram < Liquid::Block
-
     include Liquid::StandardFilters
 
     def initialize(tag, params, token)
       @limit = params.to_i
-      @user_id = ENV['JEKYLLGRAM_USER']
-      @client_id = ENV['JEKYLLGRAM_KEY']
+      @access_token = ENV['JEKYLLGRAM_TOKEN']
       @api_url = 'https://api.instagram.com/v1'
 
       super
@@ -60,7 +60,7 @@ module Jekyll
       context.stack do
         photos.each_with_index do |photo, index|
           context['photo'] = photo
-          result << render_all(@nodelist, context)
+          result << @body.render(context)
 
           break if index + 1 == @limit
         end
@@ -70,14 +70,14 @@ module Jekyll
     end
 
     def recent_photos
-      method = "/users/#{@user_id}/media/recent"
-      keys = "/?client_id=#{@client_id}"
+      method = '/users/self/media/recent'
+      keys = "/?access_token=#{@access_token}"
 
       response = Net::HTTP.get_response(URI.parse(@api_url + method + keys))
       return [] unless response.is_a?(Net::HTTPSuccess)
-      
+
       response = JSON.parse(response.body)
-      
+
       response['data']
     end
   end


### PR DESCRIPTION
This PR addresses a bug noted in Issue #1 regarding the API changes, as well as updating the plugin to work with Jekyll 4.x which uses Liquid 4.x which deprecated `Liquid::Block.render_all`. 